### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -1,5 +1,7 @@
 name: Test Runner
 
+permissions: {}
+
 on: workflow_dispatch
 
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/novaferrydianto/vuln-bank/security/code-scanning/11](https://github.com/novaferrydianto/vuln-bank/security/code-scanning/11)

The fix is to add a `permissions` block to the workflow, either at the root level (directly under the name key), or under the specific job that needs it. In this case, since the workflow is simple and the job does not use any write-privileged GitHub API operations, the least privilege approach is to set all required permissions to `read`, or if none are needed, to set `permissions: {}' (which disables all default permissions for the job). The best location for this block is at the root level of the workflow file, above the `jobs:` key to ensure all jobs inherit the minimal permissions. No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
