### PR TITLE
Potential fix for code scanning alert no. 293: Partial server-side request forgery

### DIFF
--- a/app.py
+++ b/app.py
@@ -588,20 +588,19 @@ def upload_profile_picture_url(current_user):
     try:
         data = request.get_json() or {}
         # Only accept a safe image path or identifier, not a full URL
-        image_filename = data.get('image_filename')
+        image_index = data.get('image_index')
 
         # Load the whitelist of allowed profile pictures (e.g. from disk or DB)
         AVATARS_DIR = "avatars_whitelist"  # Directory with allowed images (could point elsewhere)
         allowed_filenames = [f for f in os.listdir(AVATARS_DIR) if f.lower().endswith(('.jpg', '.jpeg', '.png', '.gif'))]
 
-        if not image_filename:
-            return jsonify({'status': 'error', 'message': 'image_filename is required'}), 400
-        # Matches only filenames (no slashes) with safe extensions
-        import re
-        if not re.fullmatch(r"[a-zA-Z0-9_\-]+\.((jpg)|(jpeg)|(png)|(gif))", image_filename or ""):
-            return jsonify({'status': 'error', 'message': 'Invalid image filename pattern'}), 400
-        if image_filename not in allowed_filenames:
-            return jsonify({'status': 'error', 'message': 'Not an approved profile picture'}), 400
+        try:
+            image_index = int(image_index)
+        except (ValueError, TypeError):
+            return jsonify({'status': 'error', 'message': 'image_index must be an integer'}), 400
+        if image_index < 0 or image_index >= len(allowed_filenames):
+            return jsonify({'status': 'error', 'message': 'image_index is out of range'}), 400
+        image_filename = allowed_filenames[image_index]
         # Restrict allowed host and URL construction
         ALLOWED_PROFILE_PIC_HOST = "images.example.com"
         BASE_PROFILE_PIC_URL = f"https://{ALLOWED_PROFILE_PIC_HOST}/avatars/"


### PR DESCRIPTION
Potential fix for [https://github.com/novaferrydianto/vuln-bank/security/code-scanning/293](https://github.com/novaferrydianto/vuln-bank/security/code-scanning/293)

To fully mitigate the partial SSRF risk, the best approach is to remove any possibility of user influence over the path component of the URL used in requests.get(), even if the user can only pick a filename from an allow-list. Rather than allowing the user to supply a filename that is directly appended to the URL, provide a pre-defined list of image filenames that users can choose from, indexed server-side, so the client submits an image ID and the server maps it to the filename (removing all user input from the URL path). Alternatively, double-check the filename against both the allow-list and using a stricter whitelist mechanism (mapping ID or picking from a set), and ensure there are no path traversal or other unintended ways for an attacker to "reach" files outside `AVATARS_DIR`.

Here's the specific fix:
- Do not use direct user input (`image_filename`) to build the request URL.
- Instead, enumerate the allow-list of safe filenames from the directory, and require the user to select an index or ID corresponding to one.
- Validate that the user-provided index/ID is an integer within allowed bounds and map that to the filename server-side.
- Build the URL using only server-side data.

Changes required:
- Replace `image_filename = data.get('image_filename')` logic with `image_index = data.get('image_index')`, validate that it's an integer in bounds, and set `image_filename` by lookup.
- Update input validation and error handling code to check the index/ID, rather than a raw filename.
- Update Swagger/openAPI and frontend API documentation if required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
