### PR TITLE
Potential fix for code scanning alert no. 12: Clear-text logging of sensitive information

### DIFF
--- a/app.py
+++ b/app.py
@@ -285,7 +285,7 @@ def login():
             
             # SQL Injection vulnerability (intentionally vulnerable)
             query = f"SELECT * FROM users WHERE username='{username}' AND password='{password}'"
-            print(f"Debug - Login query: {query}")  # Debug print
+            # print(f"Debug - Login query: {query}")  # Debug print -- REMOVED: do not log sensitive information (password)
             
             user = execute_query(query)
             print(f"Debug - Query result: {user}")  # Debug print


### PR DESCRIPTION
Potential fix for [https://github.com/novaferrydianto/vuln-bank/security/code-scanning/12](https://github.com/novaferrydianto/vuln-bank/security/code-scanning/12)

To address this security issue, we must ensure that plain-text passwords are never logged. The offending line can be changed so it does not log the entire SQL query, especially the part containing sensitive user data like passwords. For debugging purposes, you may log sanitized data—such as the username (if necessary, with care)—but passwords must always be omitted or redacted. The best fix is to remove direct logging of the query entirely, or if required for troubleshooting, replace the password with a placeholder such as `[REDACTED]` or remove it. Only the necessary non-sensitive information should remain in debug output.

The relevant change is in file `app.py`, line 288.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
